### PR TITLE
Modified reference/staging.json WEB-937

### DIFF
--- a/reference/staging.json
+++ b/reference/staging.json
@@ -2666,10 +2666,7 @@
                   }
                 }
               }
-            },
-            "text/json": null,
-            "application/*+json": null,
-            "application/xml": null
+            }
           }
         },
         "responses": {
@@ -2698,9 +2695,7 @@
               "schema": {
                 "$ref": "#/components/schemas/GlSegment"
               }
-            },
-            "text/json": null,
-            "application/*+json": null
+            }
           }
         },
         "responses": {
@@ -16026,6 +16021,7 @@
             "nullable": true
           },
           "value": {
+            "type": "string",
             "description": "The ID of the code.",
             "nullable": true
           }


### PR DESCRIPTION
Corrected some errors that seem related to fixing the response refs
- Changed the `KeyValuePair` value property to a string type. This is actually a C# object but I'm not sure of a better way to describe this in swagger and the examples causing the errors were written with strings.
- Removed empty/null mime content types